### PR TITLE
Fix importFile path construction

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -7,9 +7,16 @@ export const blocks = {
   empty: '⠀',
 }
 
-export const importFile = (filename: string): string => {
+export const importFile = (
+  directoryOrFile: string,
+  filename?: string,
+): string => {
+  const path = filename
+    ? `./${directoryOrFile}/${filename}`
+    : directoryOrFile
+
   try {
-    return readFileSync(`${filename}`, {encoding: 'utf-8'}).replace(/\r/g, '')
+    return readFileSync(path, { encoding: 'utf-8' }).replace(/\r/g, '')
   } catch (err) {
     throw new Error(`Error file parsing file - ${err}`)
   }


### PR DESCRIPTION
## Summary
- update `importFile` to accept optional directory and filename arguments

## Testing
- `npm test` *(fails: input.reduce is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f3addca508330a7ff78a9c7465e0d