### PR TITLE
Fix updateMainBadge reading error

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -51,6 +51,11 @@ export const updateMainBadge = async (year: number, day: string, parts: { p1: an
     currentCompletion = readFileSync('./utils/completion.json', {encoding: 'utf-8'})
   } catch (error) {
     console.error('Error parsing file', error)
+    return
+  }
+
+  if (!currentCompletion) {
+    return
   }
 
   const parsedData = JSON.parse(currentCompletion)


### PR DESCRIPTION
## Summary
- guard against missing `completion.json` in `updateMainBadge`
- only parse JSON when the file is read successfully

## Testing
- `npm test` *(fails: 5 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a7628848330a4d20711363b4df4