### PR TITLE
Fix badge links for AoC 2020 day22

### DIFF
--- a/2020/day22/README.md
+++ b/2020/day22/README.md
@@ -1,3 +1,3 @@
 ## JavaScript
-[![Part 1](https://img.shields.io/badge/Part%201-0.732ms-informational)](https://adventofcode.com/2021/)
-[![Part 2](https://img.shields.io/badge/Part%202-1223.622ms-informational)](https://adventofcode.com/2021/)
+[![Part 1](https://img.shields.io/badge/Part%201-0.732ms-informational)](https://adventofcode.com/2020/)
+[![Part 2](https://img.shields.io/badge/Part%202-1223.622ms-informational)](https://adventofcode.com/2020/)


### PR DESCRIPTION
## Summary
- point the day 22 badges to Advent of Code 2020

## Testing
- `npm test` *(fails: 5 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a8a64b48330b6deede6ed4c3c2e