### PR TITLE
Fix sample input usage in tests

### DIFF
--- a/2024/day02/index.test.ts
+++ b/2024/day02/index.test.ts
@@ -10,11 +10,11 @@ const SAMPLE_RESULTS = {
 
 describe(TODAY, () => {
   it('part1', () => {
-    const result = part1(parsedInput)
+    const result = part1(parsedInput('sample'))
     expect(result).toBe(SAMPLE_RESULTS.part1)
   })
   it('part2', () => {
-    const result = part2(parsedInput)
+    const result = part2(parsedInput('sample'))
     expect(result).toBe(SAMPLE_RESULTS.part2)
   })
 })

--- a/2024/day03/index.test.ts
+++ b/2024/day03/index.test.ts
@@ -10,11 +10,11 @@ const SAMPLE_RESULTS = {
 
 describe(TODAY, () => {
   it('part1', () => {
-    const result = part1(parsedInput)
+    const result = part1(parsedInput('sample'))
     expect(result).toBe(SAMPLE_RESULTS.part1)
   })
   it('part2', () => {
-    const result = part2(parsedInput)
+    const result = part2(parsedInput('sample'))
     expect(result).toBe(SAMPLE_RESULTS.part2)
   })
 })

--- a/2024/day04/index.test.ts
+++ b/2024/day04/index.test.ts
@@ -10,11 +10,11 @@ const SAMPLE_RESULTS = {
 
 describe(TODAY, () => {
   it('part1', () => {
-    const result = part1(parsedInput)
+    const result = part1(parsedInput('sample'))
     expect(result).toBe(SAMPLE_RESULTS.part1)
   })
   it('part2', () => {
-    const result = part2(parsedInput)
+    const result = part2(parsedInput('sample'))
     expect(result).toBe(SAMPLE_RESULTS.part2)
   })
 })


### PR DESCRIPTION
## Summary
- ensure tests for 2024 days 2-4 run against the sample data

## Testing
- `npm test` *(fails: part of repository has failing tests by design)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a925c308330ba00debbbe35c561