### PR TITLE
Fix importFile error message

### DIFF
--- a/utils/index.test.ts
+++ b/utils/index.test.ts
@@ -26,7 +26,7 @@ describe('importFile', () => {
   it('should throw an error if file parsing fails', () => {
     const directory = 'data'
     const filename = 'input.txt'
-    const expectedError = 'Error file parsing file - Error: Error parsing file'
+    const expectedError = 'Error parsing file - Error: Error parsing file'
 
     // Mock the readFileSync function to throw an error
     jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -18,7 +18,7 @@ export const importFile = (
   try {
     return readFileSync(path, { encoding: 'utf-8' }).replace(/\r/g, '')
   } catch (err) {
-    throw new Error(`Error file parsing file - ${err}`)
+    throw new Error(`Error parsing file - ${err}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- correct error string inside `importFile`
- update tests for new error message

## Testing
- `npx jest` *(fails: 5 failed, 8 passed)*
- `npx jest utils/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687f6a73a5e8833081886bdf202c851d